### PR TITLE
Retrieve realm roles (general roles), and extract web middleware to configuration file

### DIFF
--- a/config/keycloak-web.php
+++ b/config/keycloak-web.php
@@ -66,6 +66,15 @@ return [
         'register' => 'register',
         'callback' => 'callback',
     ],
+    
+    
+    /**
+    * Define the route middleware.
+    * Add here any custom middleware that you want to be executed for the login routes.
+    /*
+    'middlewares' => [
+        'web',
+    ],
 
     /**
     * GuzzleHttp Client options

--- a/config/keycloak-web.php
+++ b/config/keycloak-web.php
@@ -69,11 +69,11 @@ return [
     
     
     /**
-    * Define the route middleware.
-    * Add here any custom middleware that you want to be executed for the login routes.
-    /*
+     * Define the route middleware.
+     * Add here any custom middleware that you want to be executed for the login routes.
+     */
     'middlewares' => [
-        'web',
+        'web'
     ],
 
     /**

--- a/src/Auth/Guard/KeycloakWebGuard.php
+++ b/src/Auth/Guard/KeycloakWebGuard.php
@@ -166,12 +166,16 @@ class KeycloakWebGuard implements Guard
 
         $token = new KeycloakAccessToken($token);
         $token = $token->parseAccessToken();
+        
+        $realmRoles = $token['realm_access']['roles'] ?? [];
 
         $resourceRoles = $token['resource_access'] ?? [];
         $resourceRoles = $resourceRoles[ $resource ] ?? [];
         $resourceRoles = $resourceRoles['roles'] ?? [];
+        
+        $keycloakRoles = array_merge($realmRoles, $resourceRoles);
 
-        return $resourceRoles;
+        return $keycloakRoles;
     }
 
     /**

--- a/src/KeycloakWebGuardServiceProvider.php
+++ b/src/KeycloakWebGuardServiceProvider.php
@@ -95,7 +95,7 @@ class KeycloakWebGuardServiceProvider extends ServiceProvider
         $routes = Config::get('keycloak-web.routes', []);
         $routes = array_merge($defaults, $routes);
         
-        $middlewares = Config::get('keycloak-web.middlewares', ['web'])
+        $middlewares = Config::get('keycloak-web.middlewares', ['web']);
 
 
         // Register Routes

--- a/src/KeycloakWebGuardServiceProvider.php
+++ b/src/KeycloakWebGuardServiceProvider.php
@@ -94,24 +94,27 @@ class KeycloakWebGuardServiceProvider extends ServiceProvider
 
         $routes = Config::get('keycloak-web.routes', []);
         $routes = array_merge($defaults, $routes);
+        
+        $middlewares = Config::get('keycloak-web.middlewares', ['web'])
+
 
         // Register Routes
         $router = $this->app->make('router');
 
         if (! empty($routes['login'])) {
-            $router->middleware('web')->get($routes['login'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@login')->name('keycloak.login');
+            $router->middleware($middlewares)->get($routes['login'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@login')->name('keycloak.login');
         }
 
         if (! empty($routes['logout'])) {
-            $router->middleware('web')->get($routes['logout'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@logout')->name('keycloak.logout');
+            $router->middleware($middlewares)->get($routes['logout'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@logout')->name('keycloak.logout');
         }
 
         if (! empty($routes['register'])) {
-            $router->middleware('web')->get($routes['register'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@register')->name('keycloak.register');
+            $router->middleware($middlewares)->get($routes['register'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@register')->name('keycloak.register');
         }
 
         if (! empty($routes['callback'])) {
-            $router->middleware('web')->get($routes['callback'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@callback')->name('keycloak.callback');
+            $router->middleware($middlewares)->get($routes['callback'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@callback')->name('keycloak.callback');
         }
     }
 }


### PR DESCRIPTION
The roles method currently only retrieve the client roles that a user has been assigned, but not the general roles or realm roles present on the access token payload.
I don't know if there is any good reason to not include the realm roles.

realm_access: Contains a list of global roles. it is the intersection between the roles granted to the user, and the roles the client has access to.
resource_access: This contains a list of client roles.

According the definition of each key on the access token, it will be also better to compare if a user has a role in the real access, I found this as a issue on an application that i'm developing and declaring global roles and not being able to access them in my application.