### PR TITLE
change in the keycloak can middleware behaviour

### DIFF
--- a/src/Middleware/KeycloakCan.php
+++ b/src/Middleware/KeycloakCan.php
@@ -24,10 +24,12 @@ class KeycloakCan extends KeycloakAuthenticated
         }
 
         $guards = explode('|', ($guards[0] ?? ''));
-        if (Auth::hasRole($guards)) {
-            return $next($request);
+        foreach ($guards AS $guard)
+        {
+            if (Auth::hasRole($guard)) {
+                return $next($request);
+            }
         }
-
         throw new AuthorizationException('Forbidden', 403);
     }
 }


### PR DESCRIPTION
atualmente o middleware trabalha verificando se um usuário possui todas as permissões para acessar o recurso,a proposta é para que um usuário possa acessar um recurso se possui qualquer uma das permissões, por exemplo:
Considerando que um sistema possui uma role administrador que tem acesso a tudo, a minha proposta é rodar um loop e quando encontrar qualquer uma das permissões conceder acesso:
```
foreach ($guards AS $guard) {
    if (Auth::hasRole($guard)) {
        return $next($request);
    }
}
```
O mesmo comportamento de verificar multiplas roles pode ser atingido através de um novo group repetindo o middleware do keycloak, enquanto o comportamento de apenas verificar uma role não pode ser atingido sem criar um novo middleware.
Abri uma open request alterar esse comportamento