### PR TITLE
Added Laravel default GuardHelpers trait to KeycloakWebGuard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "vizir/laravel-keycloak-web-guard",
+    "name": "skarjoss/laravel-keycloak-web-guard",
     "description": "Simple Keycloak Guard to Laravel Web Routes",
     "homepage": "https://github.com/Vizir/laravel-keycloak-web-guard",
     "license": "MIT",

--- a/src/Auth/Guard/KeycloakWebGuard.php
+++ b/src/Auth/Guard/KeycloakWebGuard.php
@@ -11,9 +11,12 @@ use Vizir\KeycloakWebGuard\Exceptions\KeycloakCallbackException;
 use Vizir\KeycloakWebGuard\Models\KeycloakUser;
 use Vizir\KeycloakWebGuard\Facades\KeycloakWeb;
 use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Auth\GuardHelpers;
 
 class KeycloakWebGuard implements Guard
 {
+    use GuardHelpers;
+    
     /**
      * @var null|Authenticatable|KeycloakUser
      */


### PR DESCRIPTION
Fix for Auth::getProvider() is undefined
Error found using laravel/voyager package, which requires Auth::guard(app('VoyagerGuard'))->getProvider()->getModel() in VoyagerServiceProvider