### PR TITLE
Fix login redirect for Inertia apps.

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -15,10 +15,18 @@ class AuthController extends Controller
      *
      * @return view
      */
-    public function login()
+    public function login(Request $request)
     {
         $url = KeycloakWeb::getLoginUrl();
         KeycloakWeb::saveState();
+
+        if (class_exists('Inertia\Inertia')) {
+            if ($request->inertia()) {
+                // for Inertia AJAX requests, trigger a hard location change
+                // see https://inertiajs.com/redirects
+                return \Inertia\Inertia::location($url);
+            }
+        }
 
         return redirect($url);
     }


### PR DESCRIPTION
Inertia calls are executed via AJAX, so when one of those runs into an expired session, a CORS error will be triggered (the login redirect will result in a different URL than indicated in the preflight request).

This commit catches Inertia calls and does a hard Inertia redirect. This will not impact other AJAX calls. Also, this only needs to be handled in the keycloak.login route, since that can be triggered any time via the KeycloakAuthenticated middleware.