### PR TITLE
add realm-roles to roles-array

### DIFF
--- a/src/Auth/Guard/KeycloakWebGuard.php
+++ b/src/Auth/Guard/KeycloakWebGuard.php
@@ -199,7 +199,10 @@ class KeycloakWebGuard implements Guard
         $resourceRoles = $resourceRoles[ $resource ] ?? [];
         $resourceRoles = $resourceRoles['roles'] ?? [];
 
-        return $resourceRoles;
+        $realmRoles = $token['realm_access'] ?? [];
+        $realmRoles = $realmRoles['roles'] ?? [];
+
+        return array_merge($resourceRoles, $realmRoles);
     }
 
     /**


### PR DESCRIPTION
For a use case I have to also take the realm roles into consideration. Up to now only the resource roles are honored. Since the realm roles serve as a kind of overarching roles, it would be good to include them also in the roles-array of the WebGuard.