### PR TITLE
fix: prevent infinite authentication loop while refreshing token

### DIFF
--- a/src/Auth/Guard/KeycloakWebGuard.php
+++ b/src/Auth/Guard/KeycloakWebGuard.php
@@ -52,7 +52,7 @@ class KeycloakWebGuard implements Guard
      */
     public function hasUser()
     {
-        return (bool) $this->user();
+        return (bool) $this->user;
     }
 
     /**
@@ -100,7 +100,7 @@ class KeycloakWebGuard implements Guard
         $user = $this->user();
         return $user->id ?? null;
     }
-    
+
     /**
     * Disable viaRemember methode used by some bundles (like filament)
     *
@@ -168,7 +168,7 @@ class KeycloakWebGuard implements Guard
 
         return true;
     }
-    
+
     /**
      * Check user is authenticated and return his resource roles
      *


### PR DESCRIPTION
Change `hasUser()` implementation to prevent authentication flow.

This function should only indicate if there is an user, not trying to retrieve it.

I faced problems while using Keycloak and Laravel Telescope when a token was expired.
The code on `KeycloakService:275`  tries to log an exception using the Log facade.

While logging an event is created, Laravel Telescope listens to this to record a log line.
In `Telescope:316` telescope checks if there is an authenticated user. Previously this would re-trigger the authentication flow which would make an infinite loop, since the token is expired. 