### PR TITLE
[Security improvement] MD5 to SHA256 + multiple config sources for OpenId

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,34 @@ We can cache the OpenId Configuration: it's a list of endpoints we require to Ke
 
 If you activate it, *remember to flush the cache* when change the realm or url.
 
+## Security Configuration
+
+For enhanced security, this package supports multiple ways to load OpenID configuration, avoiding public exposure of the `.well-known/openid-configuration` endpoint.
+
+### OpenID Configuration Sources
+
+You can configure how the OpenID configuration is loaded using the `KEYCLOAK_OPENID_SOURCE` environment variable:
+
+**Option 1: Remote (Default - Less Secure)**
+```env
+KEYCLOAK_OPENID_SOURCE=remote
+```
+Loads configuration from the public `.well-known/openid-configuration` endpoint.
+
+**Option 2: Local File (Recommended)**
+```env
+KEYCLOAK_OPENID_SOURCE=local
+KEYCLOAK_OPENID_LOCAL_PATH=/absolute/path/to/openid-configuration.json
+```
+Loads configuration from a local JSON file.
+
+**Option 3: Base64 Encoded (Highly Secure)**
+```env
+KEYCLOAK_OPENID_SOURCE=base64
+KEYCLOAK_OPENID_BASE64_CONFIG=eyJpc3N1ZXIiOiJodHRwczovL3lvdXIta2V5Y2xvYWstc2VydmVyLmNvbS9yZWFsbXMveW91ci1yZWFsbSIsIi4uLn0=
+```
+Stores configuration as base64-encoded JSON in environment variables.
+
 Just add the options you would like as an array to the" to "Just add the options you would like to guzzle_options array on keycloak-web.php config file. For example:
 
 ## Laravel Auth

--- a/config/keycloak-web.php
+++ b/config/keycloak-web.php
@@ -45,6 +45,32 @@ return [
     'cache_openid' => env('KEYCLOAK_CACHE_OPENID', false),
 
     /**
+     * OpenID Configuration Source
+     * 
+     * Options:
+     * - 'remote': Fetch from the public .well-known endpoint (default, less secure)
+     * - 'local': Load from a local file path
+     * - 'base64': Load from base64 encoded configuration in env/config
+     */
+    'openid_source' => env('KEYCLOAK_OPENID_SOURCE', 'remote'),
+
+    /**
+     * Local OpenID Configuration File Path
+     * 
+     * Used when openid_source is 'local'
+     * Path to a local JSON file containing the OpenID configuration
+     */
+    'openid_local_path' => env('KEYCLOAK_OPENID_LOCAL_PATH', storage_path('app/keycloak/openid-configuration.json')),
+
+    /**
+     * Base64 Encoded OpenID Configuration
+     * 
+     * Used when openid_source is 'base64'
+     * Base64 encoded JSON string of the OpenID configuration
+     */
+    'openid_base64_config' => env('KEYCLOAK_OPENID_BASE64_CONFIG', null),
+
+    /**
      * Page to redirect after callback if there's no "intent"
      *
      * @see Vizir\KeycloakWebGuard\Controllers\AuthController::callback()

--- a/storage/app/keycloak/openid-configuration.sample.json
+++ b/storage/app/keycloak/openid-configuration.sample.json
@@ -1,0 +1,240 @@
+{
+  "issuer": "https://your-keycloak-server.com/realms/your-realm",
+  "authorization_endpoint": "https://your-keycloak-server.com/realms/your-realm/protocol/openid-connect/auth",
+  "token_endpoint": "https://your-keycloak-server.com/realms/your-realm/protocol/openid-connect/token",
+  "introspection_endpoint": "https://your-keycloak-server.com/realms/your-realm/protocol/openid-connect/token/introspect",
+  "userinfo_endpoint": "https://your-keycloak-server.com/realms/your-realm/protocol/openid-connect/userinfo",
+  "end_session_endpoint": "https://your-keycloak-server.com/realms/your-realm/protocol/openid-connect/logout",
+  "frontchannel_logout_session_supported": true,
+  "frontchannel_logout_supported": true,
+  "jwks_uri": "https://your-keycloak-server.com/realms/your-realm/protocol/openid-connect/certs",
+  "check_session_iframe": "https://your-keycloak-server.com/realms/your-realm/protocol/openid-connect/login-status-iframe.html",
+  "grant_types_supported": [
+    "authorization_code",
+    "implicit",
+    "refresh_token",
+    "password",
+    "client_credentials",
+    "urn:ietf:params:oauth:grant-type:device_code",
+    "urn:openid:params:grant-type:ciba"
+  ],
+  "response_types_supported": [
+    "code",
+    "none",
+    "id_token",
+    "token",
+    "id_token token",
+    "code id_token",
+    "code token",
+    "code id_token token"
+  ],
+  "subject_types_supported": [
+    "public",
+    "pairwise"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "PS384",
+    "ES384",
+    "RS384",
+    "HS256",
+    "HS512",
+    "ES256",
+    "RS256",
+    "HS384",
+    "ES512",
+    "PS256",
+    "PS512",
+    "RS512"
+  ],
+  "id_token_encryption_alg_values_supported": [
+    "RSA-OAEP",
+    "RSA-OAEP-256",
+    "RSA1_5"
+  ],
+  "id_token_encryption_enc_values_supported": [
+    "A256GCM",
+    "A192GCM",
+    "A128GCM",
+    "A128CBC-HS256",
+    "A192CBC-HS384",
+    "A256CBC-HS512"
+  ],
+  "userinfo_signing_alg_values_supported": [
+    "PS384",
+    "ES384",
+    "RS384",
+    "HS256",
+    "HS512",
+    "ES256",
+    "RS256",
+    "HS384",
+    "ES512",
+    "PS256",
+    "PS512",
+    "RS512",
+    "none"
+  ],
+  "request_object_signing_alg_values_supported": [
+    "PS384",
+    "ES384",
+    "RS384",
+    "HS256",
+    "HS512",
+    "ES256",
+    "RS256",
+    "HS384",
+    "ES512",
+    "PS256",
+    "PS512",
+    "RS512",
+    "none"
+  ],
+  "request_object_encryption_alg_values_supported": [
+    "RSA-OAEP",
+    "RSA-OAEP-256",
+    "RSA1_5"
+  ],
+  "request_object_encryption_enc_values_supported": [
+    "A256GCM",
+    "A192GCM",
+    "A128GCM",
+    "A128CBC-HS256",
+    "A192CBC-HS384",
+    "A256CBC-HS512"
+  ],
+  "response_modes_supported": [
+    "query",
+    "fragment",
+    "form_post",
+    "query.jwt",
+    "fragment.jwt",
+    "form_post.jwt"
+  ],
+  "registration_endpoint": "https://your-keycloak-server.com/realms/your-realm/clients-registrations/openid-connect",
+  "token_endpoint_auth_methods_supported": [
+    "private_key_jwt",
+    "client_secret_basic",
+    "client_secret_post",
+    "tls_client_auth",
+    "client_secret_jwt"
+  ],
+  "token_endpoint_auth_signing_alg_values_supported": [
+    "PS384",
+    "ES384",
+    "RS384",
+    "HS256",
+    "HS512",
+    "ES256",
+    "RS256",
+    "HS384",
+    "ES512",
+    "PS256",
+    "PS512",
+    "RS512"
+  ],
+  "introspection_endpoint_auth_methods_supported": [
+    "private_key_jwt",
+    "client_secret_basic",
+    "client_secret_post",
+    "tls_client_auth",
+    "client_secret_jwt"
+  ],
+  "introspection_endpoint_auth_signing_alg_values_supported": [
+    "PS384",
+    "ES384",
+    "RS384",
+    "HS256",
+    "HS512",
+    "ES256",
+    "RS256",
+    "HS384",
+    "ES512",
+    "PS256",
+    "PS512",
+    "RS512"
+  ],
+  "authorization_signing_alg_values_supported": [
+    "PS384",
+    "ES384",
+    "RS384",
+    "HS256",
+    "HS512",
+    "ES256",
+    "RS256",
+    "HS384",
+    "ES512",
+    "PS256",
+    "PS512",
+    "RS512"
+  ],
+  "authorization_encryption_alg_values_supported": [
+    "RSA-OAEP",
+    "RSA-OAEP-256",
+    "RSA1_5"
+  ],
+  "authorization_encryption_enc_values_supported": [
+    "A256GCM",
+    "A192GCM",
+    "A128GCM",
+    "A128CBC-HS256",
+    "A192CBC-HS384",
+    "A256CBC-HS512"
+  ],
+  "claims_supported": [
+    "aud",
+    "sub",
+    "iss",
+    "auth_time",
+    "name",
+    "given_name",
+    "family_name",
+    "preferred_username",
+    "email",
+    "acr"
+  ],
+  "claim_types_supported": [
+    "normal"
+  ],
+  "claims_parameter_supported": true,
+  "scopes_supported": [
+    "openid",
+    "profile",
+    "email",
+    "address",
+    "phone",
+    "offline_access",
+    "microprofile-jwt"
+  ],
+  "request_parameter_supported": true,
+  "request_uri_parameter_supported": true,
+  "require_request_uri_registration": true,
+  "code_challenge_methods_supported": [
+    "plain",
+    "S256"
+  ],
+  "tls_client_certificate_bound_access_tokens": true,
+  "revocation_endpoint": "https://your-keycloak-server.com/realms/your-realm/protocol/openid-connect/revoke",
+  "revocation_endpoint_auth_methods_supported": [
+    "private_key_jwt",
+    "client_secret_basic",
+    "client_secret_post",
+    "tls_client_auth",
+    "client_secret_jwt"
+  ],
+  "revocation_endpoint_auth_signing_alg_values_supported": [
+    "PS384",
+    "ES384",
+    "RS384",
+    "HS256",
+    "HS512",
+    "ES256",
+    "RS256",
+    "HS384",
+    "ES512",
+    "PS256",
+    "PS512",
+    "RS512"
+  ],
+  "backchannel_logout_supported": true,
+  "backchannel_logout_session_supported": true
+}


### PR DESCRIPTION
- SHA256 Hashing: Cache keys now use SHA256 instead of MD5 to remove deprecated algorithms and satisfy security audit requirements
- OpenID Configuration Source Options: Introduce Local and base64 options eliminate public exposure of Keycloak configuration